### PR TITLE
Fix makefile object order for correct dependency

### DIFF
--- a/examples/raw/Makefile
+++ b/examples/raw/Makefile
@@ -6,5 +6,9 @@ CFLAGS += -I../../include
 LDFLAGS += ../../lib/libTinyGL.a -lm
 
 all: $(ALL_T)
+
+$(ALL_T): %: %.c
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
 clean:
 	$(RM) $(ALL_T)

--- a/examples/sdl/Makefile
+++ b/examples/sdl/Makefile
@@ -11,5 +11,8 @@ LDFLAGS += $(shell $(SDL_CONFIG) --libs)
 
 all: $(ALL_T)
 
+$(ALL_T): %: %.c
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
 clean:
 	$(RM) $(ALL_T)


### PR DESCRIPTION
I couldn't build the example with the original makefile. This is the output when I try to use it:

```
> make sdl_examples
make[1]: Entering directory '/home/rin/Github/tinygl/examples/sdl'
cc -Wall -O3 -std=c99 -DNDEBUG -Wno-unused-function -I../../include -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT   ../../lib/libTinyGL.a -lm -L/usr/lib/x86_64-linux-gnu -lSDL  gears.c   -o gears
/usr/bin/ld: /tmp/ccJdxco2.o: in function `gear.constprop.0':
gears.c:(.text+0x23): undefined reference to `tglNormal3f'
/usr/bin/ld: gears.c:(.text+0x45): undefined reference to `tglBegin'
/usr/bin/ld: gears.c:(.text+0xc5): undefined reference to `sincos'
/usr/bin/ld: gears.c:(.text+0x122): undefined reference to `tglVertex3f'
/usr/bin/ld: gears.c:(.text+0x159): undefined reference to `tglVertex3f'
/usr/bin/ld: gears.c:(.text+0x175): undefined reference to `tglVertex3f'
/usr/bin/ld: gears.c:(.text+0x1ae): undefined reference to `sincos'
...
```

As the output shows, the linker can't find the related symbol in the shared library/static library. To solve this problem, we should put `$(LDFLAGS)` after `*.c` file(s) to provide the correct dependency.