### PR TITLE
Port the SDL examples to SDL2

### DIFF
--- a/examples/sdl/Makefile
+++ b/examples/sdl/Makefile
@@ -5,7 +5,7 @@ ALL_T= gears texture model helloworld menu game
 CFLAGS += -I../../include
 LDFLAGS += ../../lib/libTinyGL.a -lm
 
-SDL_CONFIG ?= sdl-config
+SDL_CONFIG ?= sdl2-config
 CFLAGS += $(shell $(SDL_CONFIG) --cflags)
 LDFLAGS += $(shell $(SDL_CONFIG) --libs)
 

--- a/examples/sdl/game.c
+++ b/examples/sdl/game.c
@@ -249,11 +249,23 @@ int main(int argc, char** argv) {
 #ifdef PLAY_MUSIC
 	ainit(0);
 #endif
-	SDL_Surface* screen = NULL;
-	if ((screen = SDL_SetVideoMode(winSizeX, winSizeY, TGL_FEATURE_RENDER_BITS, SDL_SWSURFACE)) == 0) {
-		fprintf(stderr, "ERROR: Video mode set failed.\n");
+	SDL_Window *window = NULL;
+        SDL_Renderer *renderer = NULL;
+        SDL_Surface *screen = NULL;
+	if ((window = SDL_CreateWindow(argv[0], SDL_WINDOWPOS_UNDEFINED,
+                                SDL_WINDOWPOS_UNDEFINED, winSizeX, winSizeY, 0)) == 0) {
+		fprintf(stderr, "ERROR: cannot create SDL window.\n");
 		return 1;
-	}
+        }
+        if((renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE)) == 0) {
+		fprintf(stderr, "ERROR: cannot create SDL renderer.\n");
+                return 1;
+        }
+
+        if((screen = SDL_GetWindowSurface(window)) == 0) {
+		fprintf(stderr, "ERROR: cannot get window surface.\n");
+                return 1;
+        }
 
 #if TGL_FEATURE_RENDER_BITS == 32
 	if (screen->format->Rmask != 0x00FF0000 || screen->format->Gmask != 0x0000FF00 || screen->format->Bmask != 0x000000FF) {
@@ -269,22 +281,24 @@ int main(int argc, char** argv) {
 #endif
 
 	SDL_ShowCursor(SDL_DISABLE);
-	SDL_WM_SetCaption(argv[0], 0);
 
 	// initialize TinyGL:
+        SDL_Texture* texture = NULL;
 	switch (screen->format->BitsPerPixel) {
 	case 8:
 		fprintf(stderr, "ERROR: Palettes are currently not supported.\n");
 		return 1;
 	case 16:
-		// fprintf(stderr,"\nUnsupported by maintainer!!!");
-		// return 1;
+		fprintf(stderr,"\nUnsupported by maintainer!!!");
+		return 1;
 		break;
 	case 24:
 		fprintf(stderr, "\nUnsupported by maintainer!!!");
 		return 1;
 		break;
 	case 32:
+                texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA32,
+                        SDL_TEXTUREACCESS_STREAMING, winSizeX, winSizeY);
 		break;
 	default:
 		return 1;
@@ -460,7 +474,10 @@ int main(int argc, char** argv) {
 		ZB_copyFrameBuffer(frameBuffer, screen->pixels, screen->pitch);
 		if (SDL_MUSTLOCK(screen))
 			SDL_UnlockSurface(screen);
-		SDL_Flip(screen);
+                SDL_UpdateTexture(texture, NULL, screen->pixels, screen->pitch);
+                SDL_RenderClear(renderer);
+                SDL_RenderCopy(renderer, texture, NULL, NULL);
+                SDL_RenderPresent(renderer);
 		if (fps > 0)
 			if ((1000 / fps) > (SDL_GetTicks() - tNow)) {
 				SDL_Delay((1000 / fps) - (SDL_GetTicks() - tNow)); // Yay stable framerate!

--- a/examples/sdl/game.c
+++ b/examples/sdl/game.c
@@ -504,8 +504,12 @@ int main(int argc, char** argv) {
 		glDeleteLists(modelDisplayList, 1);
 	ZB_close(frameBuffer);
 	glClose();
-	if (SDL_WasInit(SDL_INIT_VIDEO))
+	if (SDL_WasInit(SDL_INIT_VIDEO)) {
 		SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                SDL_DestroyTexture(texture);
+                SDL_DestroyRenderer(renderer);
+                SDL_DestroyWindow(window);
+        }
 #ifdef PLAY_MUSIC
 	mhalt();
 	Mix_FreeMusic(myTrack);

--- a/examples/sdl/gears.c
+++ b/examples/sdl/gears.c
@@ -576,8 +576,12 @@ int main(int argc, char** argv) {
 	ZB_close(frameBuffer);
 	glClose();
 	if (!noSDL)
-		if (SDL_WasInit(SDL_INIT_VIDEO))
+		if (SDL_WasInit(SDL_INIT_VIDEO)) {
 			SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                        SDL_DestroyTexture(texture);
+                        SDL_DestroyRenderer(renderer);
+                        SDL_DestroyWindow(window);
+                }
 #ifdef PLAY_MUSIC
 	if (!noSDL)
 		mhalt();

--- a/examples/sdl/helloworld.c
+++ b/examples/sdl/helloworld.c
@@ -145,12 +145,26 @@ int main(int argc, char** argv) {
 	if (!noSDL)
 		ainit(0);
 #endif
-	SDL_Surface* screen = NULL;
-	if (!noSDL)
-		if ((screen = SDL_SetVideoMode(winSizeX, winSizeY, TGL_FEATURE_RENDER_BITS, SDL_SWSURFACE)) == 0) {
+	SDL_Window *window = NULL;
+        SDL_Renderer *renderer = NULL;
+        SDL_Surface *screen = NULL;
+	if (!noSDL) {
+		if ((window = SDL_CreateWindow(argv[0], SDL_WINDOWPOS_UNDEFINED,
+                                        SDL_WINDOWPOS_UNDEFINED, winSizeX, winSizeY, 0)) == 0) {
 			fprintf(stderr, "ERROR: Video mode set failed.\n");
 			return 1;
 		}
+
+                if((renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE)) == 0) {
+			fprintf(stderr, "ERROR: cannot create SDL renderer.\n");
+                        return 1;
+                }
+
+                if((screen = SDL_GetWindowSurface(window)) == 0) {
+			fprintf(stderr, "ERROR: cannot get window surface.\n");
+                        return 1;
+                }
+        }
 	if (!noSDL) {
 		printf("\nRMASK IS %u", screen->format->Rmask);
 		printf("\nGMASK IS %u", screen->format->Gmask);
@@ -181,12 +195,10 @@ int main(int argc, char** argv) {
 #endif
 	if (!noSDL)
 		SDL_ShowCursor(SDL_DISABLE);
-	if (!noSDL)
-		SDL_WM_SetCaption(argv[0], 0);
 
 	// initialize TinyGL:
 	// unsigned int pitch;
-	int mode;
+        SDL_Texture* texture = NULL;
 	if (!noSDL)
 		switch (screen->format->BitsPerPixel) {
 		case 8:
@@ -195,19 +207,18 @@ int main(int argc, char** argv) {
 			return 1;
 		case 16:
 
-			// fprintf(stderr,"\nUnsupported by maintainer!!!");
-			mode = ZB_MODE_5R6G5B;
-			// return 1;
+			fprintf(stderr,"\nUnsupported by maintainer!!!");
+			return 1;
 			break;
 		case 24:
 
 			fprintf(stderr, "\nUnsupported by maintainer!!!");
-			mode = ZB_MODE_RGB24;
 			return 1;
 			break;
 		case 32:
 
-			mode = ZB_MODE_RGBA;
+                        texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA32,
+                                SDL_TEXTUREACCESS_STREAMING, winSizeX, winSizeY);
 			break;
 		default:
 			return 1;
@@ -296,8 +307,12 @@ int main(int argc, char** argv) {
 		if (!noSDL)
 			if (SDL_MUSTLOCK(screen))
 				SDL_UnlockSurface(screen);
-		if (!noSDL)
-			SDL_Flip(screen);
+		if (!noSDL) {
+                        SDL_UpdateTexture(texture, NULL, screen->pixels, screen->pitch);
+                        SDL_RenderClear(renderer);
+                        SDL_RenderCopy(renderer, texture, NULL, NULL);
+                        SDL_RenderPresent(renderer);
+                }
 		if (!noSDL)
 			if (fps > 0)
 				if ((1000 / fps) > (SDL_GetTicks() - tNow)) {
@@ -305,7 +320,7 @@ int main(int argc, char** argv) {
 				}
 		// check for error conditions:
 		{
-			char* sdl_error = SDL_GetError();
+			const char* sdl_error = SDL_GetError();
 			if (sdl_error[0] != '\0') {
 				fprintf(stderr, "SDL ERROR: \"%s\"\n", sdl_error);
 				SDL_ClearError();

--- a/examples/sdl/helloworld.c
+++ b/examples/sdl/helloworld.c
@@ -339,8 +339,12 @@ int main(int argc, char** argv) {
 	ZB_close(frameBuffer);
 	glClose();
 	if (!noSDL)
-		if (SDL_WasInit(SDL_INIT_VIDEO))
+		if (SDL_WasInit(SDL_INIT_VIDEO)) {
 			SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                        SDL_DestroyTexture(texture);
+                        SDL_DestroyRenderer(renderer);
+                        SDL_DestroyWindow(window);
+                }
 #ifdef PLAY_MUSIC
 	if (!noSDL)
 		mhalt();

--- a/examples/sdl/menu.c
+++ b/examples/sdl/menu.c
@@ -332,11 +332,23 @@ int main(int argc, char** argv) {
 #ifdef PLAY_MUSIC
 	ainit(0);
 #endif
-	SDL_Surface* screen = NULL;
-	if ((screen = SDL_SetVideoMode(winSizeX, winSizeY, TGL_FEATURE_RENDER_BITS, SDL_SWSURFACE)) == 0) {
-		fprintf(stderr, "ERROR: Video mode set failed.\n");
+	SDL_Window *window = NULL;
+        SDL_Renderer *renderer = NULL;
+        SDL_Surface *screen = NULL;
+	if ((window = SDL_CreateWindow(argv[0], SDL_WINDOWPOS_UNDEFINED,
+                                SDL_WINDOWPOS_UNDEFINED, winSizeX, winSizeY, 0)) == 0) {
+		fprintf(stderr, "ERROR: cannot create SDL window.\n");
 		return 1;
-	}
+        }
+        if((renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE)) == 0) {
+		fprintf(stderr, "ERROR: cannot create SDL renderer.\n");
+                return 1;
+        }
+
+        if((screen = SDL_GetWindowSurface(window)) == 0) {
+		fprintf(stderr, "ERROR: cannot get window surface.\n");
+                return 1;
+        }
 	printf("\nRMASK IS %u", screen->format->Rmask);
 	printf("\nGMASK IS %u", screen->format->Gmask);
 	printf("\nBMASK IS %u", screen->format->Bmask);
@@ -361,17 +373,17 @@ int main(int argc, char** argv) {
 	mplay(myTrack, -1, 1000);
 #endif
 	SDL_ShowCursor(SDL_ENABLE);
-	SDL_WM_SetCaption(argv[0], 0);
 
 	// initialize TinyGL:
 
 	int mode;
+        SDL_Texture* texture = NULL;
 	switch (screen->format->BitsPerPixel) {
 	case 16:
 
-		// fprintf(stderr,"\nUnsupported by maintainer!!!");
-		mode = ZB_MODE_5R6G5B;
-		// return 1;
+		fprintf(stderr,"\nUnsupported by maintainer!!!");
+		//mode = ZB_MODE_5R6G5B;
+		return 1;
 		break;
 	case 32:
 
@@ -441,13 +453,16 @@ int main(int argc, char** argv) {
 		ZB_copyFrameBuffer(frameBuffer, screen->pixels, screen->pitch);
 		if (SDL_MUSTLOCK(screen))
 			SDL_UnlockSurface(screen);
-		SDL_Flip(screen);
+                SDL_UpdateTexture(texture, NULL, screen->pixels, screen->pitch);
+                SDL_RenderClear(renderer);
+                SDL_RenderCopy(renderer, texture, NULL, NULL);
+                SDL_RenderPresent(renderer);
 		if (fps > 0)
 			if ((1000 / fps) > (SDL_GetTicks() - tNow)) {
 				SDL_Delay((1000 / fps) - (SDL_GetTicks() - tNow)); // Yay stable framerate!
 			}
 		// check for error conditions:
-		char* sdl_error = SDL_GetError();
+		const char* sdl_error = SDL_GetError();
 		if (sdl_error[0] != '\0') {
 			fprintf(stderr, "SDL ERROR: \"%s\"\n", sdl_error);
 			SDL_ClearError();

--- a/examples/sdl/menu.c
+++ b/examples/sdl/menu.c
@@ -479,8 +479,12 @@ int main(int argc, char** argv) {
 	// cleanup:
 	ZB_close(frameBuffer);
 	glClose();
-	if (SDL_WasInit(SDL_INIT_VIDEO))
+	if (SDL_WasInit(SDL_INIT_VIDEO)) {
 		SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                SDL_DestroyTexture(texture);
+                SDL_DestroyRenderer(renderer);
+                SDL_DestroyWindow(window);
+        }
 #ifdef PLAY_MUSIC
 	mhalt();
 	Mix_FreeMusic(myTrack);

--- a/examples/sdl/model.c
+++ b/examples/sdl/model.c
@@ -735,7 +735,12 @@ int main(int argc, char** argv) {
 	ZB_close(frameBuffer);
 	glClose();
 	if (SDL_WasInit(SDL_INIT_VIDEO))
+        {
 		SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                SDL_DestroyTexture(texture);
+                SDL_DestroyRenderer(renderer);
+                SDL_DestroyWindow(window);
+        }
 #ifdef PLAY_MUSIC
 	mhalt();
 	Mix_FreeMusic(myTrack);

--- a/examples/sdl/model.c
+++ b/examples/sdl/model.c
@@ -340,11 +340,23 @@ int main(int argc, char** argv) {
 #ifdef PLAY_MUSIC
 	ainit(0);
 #endif
-	SDL_Surface* screen = NULL;
-	if ((screen = SDL_SetVideoMode(winSizeX, winSizeY, TGL_FEATURE_RENDER_BITS, SDL_SWSURFACE)) == 0) {
-		fprintf(stderr, "ERROR: Video mode set failed.\n");
+	SDL_Window *window = NULL;
+        SDL_Renderer *renderer = NULL;
+        SDL_Surface *screen = NULL;
+	if ((window = SDL_CreateWindow(argv[0], SDL_WINDOWPOS_UNDEFINED,
+                                SDL_WINDOWPOS_UNDEFINED, winSizeX, winSizeY, 0)) == 0) {
+		fprintf(stderr, "ERROR: cannot create SDL window.\n");
 		return 1;
-	}
+        }
+        if((renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE)) == 0) {
+		fprintf(stderr, "ERROR: cannot create SDL renderer.\n");
+                return 1;
+        }
+
+        if((screen = SDL_GetWindowSurface(window)) == 0) {
+		fprintf(stderr, "ERROR: cannot get window surface.\n");
+                return 1;
+        }
 	printf("\nRMASK IS %u", screen->format->Rmask);
 	printf("\nGMASK IS %u", screen->format->Gmask);
 	printf("\nBMASK IS %u", screen->format->Bmask);
@@ -368,27 +380,25 @@ int main(int argc, char** argv) {
 #endif
 
 	SDL_ShowCursor(SDL_DISABLE);
-	SDL_WM_SetCaption(argv[0], 0);
 
 	// initialize TinyGL:
-	int mode;
+        SDL_Texture* texture = NULL;
 	switch (screen->format->BitsPerPixel) {
 	case 8:
 		fprintf(stderr, "ERROR: Palettes are currently not supported.\n");
 		fprintf(stderr, "\nUnsupported by maintainer!!!");
 		return 1;
 	case 16:
-		// fprintf(stderr,"\nUnsupported by maintainer!!!");
-		mode = ZB_MODE_5R6G5B;
-		// return 1;
+		fprintf(stderr,"\nUnsupported by maintainer!!!");
+		return 1;
 		break;
 	case 24:
 		fprintf(stderr, "\nUnsupported by maintainer!!!");
-		mode = ZB_MODE_RGB24;
 		return 1;
 		break;
 	case 32:
-		mode = ZB_MODE_RGBA;
+                texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA32,
+                        SDL_TEXTUREACCESS_STREAMING, winSizeX, winSizeY);
 		break;
 	default:
 		return 1;
@@ -693,13 +703,16 @@ int main(int argc, char** argv) {
 		ZB_copyFrameBuffer(frameBuffer, screen->pixels, screen->pitch);
 		if (SDL_MUSTLOCK(screen))
 			SDL_UnlockSurface(screen);
-		SDL_Flip(screen);
+                SDL_UpdateTexture(texture, NULL, screen->pixels, screen->pitch);
+                SDL_RenderClear(renderer);
+                SDL_RenderCopy(renderer, texture, NULL, NULL);
+                SDL_RenderPresent(renderer);
 		if (fps > 0)
 			if ((1000 / fps) > (SDL_GetTicks() - tNow)) {
 				SDL_Delay((1000 / fps) - (SDL_GetTicks() - tNow)); // Yay stable framerate!
 			}
 		// check for error conditions:
-		char* sdl_error = SDL_GetError();
+		const char* sdl_error = SDL_GetError();
 		if (sdl_error[0] != '\0') {
 			fprintf(stderr, "SDL ERROR: \"%s\"\n", sdl_error);
 			SDL_ClearError();

--- a/examples/sdl/texture.c
+++ b/examples/sdl/texture.c
@@ -186,11 +186,23 @@ int main(int argc, char** argv) {
 #ifdef PLAY_MUSIC
 	ainit(0);
 #endif
-	SDL_Surface* screen = NULL;
-	if ((screen = SDL_SetVideoMode(winSizeX, winSizeY, TGL_FEATURE_RENDER_BITS, SDL_SWSURFACE)) == 0) {
-		fprintf(stderr, "ERROR: Video mode set failed.\n");
+	SDL_Window *window = NULL;
+        SDL_Renderer *renderer = NULL;
+        SDL_Surface *screen = NULL;
+	if ((window = SDL_CreateWindow(argv[0], SDL_WINDOWPOS_UNDEFINED,
+                                SDL_WINDOWPOS_UNDEFINED, winSizeX, winSizeY, 0)) == 0) {
+		fprintf(stderr, "ERROR: cannot create SDL window.\n");
 		return 1;
-	}
+        }
+        if((renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE)) == 0) {
+		fprintf(stderr, "ERROR: cannot create SDL renderer.\n");
+                return 1;
+        }
+
+        if((screen = SDL_GetWindowSurface(window)) == 0) {
+		fprintf(stderr, "ERROR: cannot get window surface.\n");
+                return 1;
+        }
 	printf("\nRMASK IS %u", screen->format->Rmask);
 	printf("\nGMASK IS %u", screen->format->Gmask);
 	printf("\nBMASK IS %u", screen->format->Bmask);
@@ -215,18 +227,19 @@ int main(int argc, char** argv) {
 	mplay(myTrack, -1, 1000);
 #endif
 	SDL_ShowCursor(SDL_DISABLE);
-	SDL_WM_SetCaption(argv[0], 0);
 
 	// initialize TinyGL:
-
+        SDL_Texture* texture = NULL;
 	switch (screen->format->BitsPerPixel) {
 	case 16:
 
-		// fprintf(stderr,"\nUnsupported by maintainer!!!");
+		fprintf(stderr,"\nUnsupported by maintainer!!!");
 
-		// return 1;
+		return 1;
 		break;
 	case 32:
+                texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA32,
+                        SDL_TEXTUREACCESS_STREAMING, winSizeX, winSizeY);
 		break;
 	default:
 		return 1;
@@ -322,13 +335,16 @@ int main(int argc, char** argv) {
 		ZB_copyFrameBuffer(frameBuffer, screen->pixels, screen->pitch);
 		if (SDL_MUSTLOCK(screen))
 			SDL_UnlockSurface(screen);
-		SDL_Flip(screen);
+                SDL_UpdateTexture(texture, NULL, screen->pixels, screen->pitch);
+                SDL_RenderClear(renderer);
+                SDL_RenderCopy(renderer, texture, NULL, NULL);
+                SDL_RenderPresent(renderer);
 		if (fps > 0)
 			if ((1000 / fps) > (SDL_GetTicks() - tNow)) {
 				SDL_Delay((1000 / fps) - (SDL_GetTicks() - tNow)); // Yay stable framerate!
 			}
 		// check for error conditions:
-		char* sdl_error = SDL_GetError();
+		const char* sdl_error = SDL_GetError();
 		if (sdl_error[0] != '\0') {
 			fprintf(stderr, "SDL ERROR: \"%s\"\n", sdl_error);
 			SDL_ClearError();

--- a/examples/sdl/texture.c
+++ b/examples/sdl/texture.c
@@ -361,8 +361,12 @@ int main(int argc, char** argv) {
 	// cleanup:
 	ZB_close(frameBuffer);
 	glClose();
-	if (SDL_WasInit(SDL_INIT_VIDEO))
+	if (SDL_WasInit(SDL_INIT_VIDEO)) {
 		SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                SDL_DestroyTexture(texture);
+                SDL_DestroyRenderer(renderer);
+                SDL_DestroyWindow(window);
+        }
 #ifdef PLAY_MUSIC
 	mhalt();
 	Mix_FreeMusic(myTrack);


### PR DESCRIPTION
I am watching issue #1 and trying to give a simple solution without heavily modifying the code base. In other words, if we only want a simple solution to port examples from SDL1.2 to SDL2, we can keep using the remaining API between SDL1.2 and SDL2 and exchanging the expired API directly.

However, I am not sure if this is a good solution because it keeps using the `SDL_Surface` object. And I feel like according to the [SDL 1.2 to 2.0 Migration Guide](https://wiki.libsdl.org/MigrationGuide), we don't need to work on the 'SDL_Surface' object but could still do the same result of examples. It means that we could use the SDL2 APIs more like the document shows us.

But maybe we can just enable to use SDL2 now and refine those examples in the future.