### PR TITLE
Fix incorrect buffer range check of glDrawText

### DIFF
--- a/src/ztext.c
+++ b/src/ztext.c
@@ -88,7 +88,7 @@ void glDrawText(const GLubyte *text, GLint x, GLint y, GLuint p)
     GLint xoff = 0;
     GLint yoff = 0;
     GLint mult = c->textsize;
-    for (; text[i] != '\0' && y + 7 < h; i++) {
+    for (; text[i] != '\0' && y + yoff < h; i++) {
         if (text[i] != '\n' && xoff + x < w) {
             renderchar(font8x8_basic[text[i]], x + xoff, y + yoff, p);
             xoff += 8 * mult;


### PR DESCRIPTION
There's a mistake on the check of `glDrawText` to not overflow the pixel buffer. Taking `sdl/hello.c` for example, which uses the 640x480 size window, we can change the usage of `glDrawText` as the following:

```
glDrawText((unsigned char *) "Hello World!\nFrom TinyGL", 0, 474, 0x00FFFFFF);
```

Here's the result from the original codes.  We can see that although 474 is not larger than 480, no words are shown on the screen.

![image](https://user-images.githubusercontent.com/30153990/174635021-3aeee130-ad90-42f8-a9bc-12c021013bfa.png)

After this patch fix, we can see that a part of the words will be displayed on the screen now.

![image](https://user-images.githubusercontent.com/30153990/174634724-23752316-3a1c-4d40-b564-21dba09b76e2.png)
