### PR TITLE
Fix global buffer overflow at glMaterialfv

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -460,7 +460,7 @@ void glMaterialfv(GLint mode, GLint type, GLfloat *v)
               hell?*/
     if (type == GL_SHININESS)
         n = 1;
-    for (i = 0; i < 4; i++)
+    for (i = 0; i < n; i++)
         p[3 + i].f = v[i];
     for (i = n; i < 4; i++)
         p[3 + i].f = 0;


### PR DESCRIPTION
I try to build tinygl with `-fsanitize=address` and run raw_examples.
It report global-buffer-overflow.
```
==271095==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00000044f3e4 at pc 0x000000412845 bp 0x7ffd26123730 sp 0x7ffd26123720
READ of size 4 at 0x00000044f3e4 thread T0
    #0 0x412844 in tglMaterialfv /home/yuan/tinygl/src/api.c:464
    #1 0x40e1c3 in init_scene /home/yuan/tinygl/examples/raw/gears.c:254
    #2 0x40a54f in main /home/yuan/tinygl/examples/raw/gears.c:362
    #3 0x7f3b7f3cd082 in __libc_start_main ../csu/libc-start.c:308
    #4 0x4023ad in _start (/home/yuan/tinygl/examples/raw/gears+0x4023ad)
```